### PR TITLE
Add support for Intel GPU to Word Language Model Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ docs/venv
 
 # development
 .vscode
+.venv
 **/.DS_Store

--- a/fast_neural_style/README.md
+++ b/fast_neural_style/README.md
@@ -26,8 +26,9 @@ python neural_style/neural_style.py eval --content-image </path/to/content/image
 - `--model`: saved model to be used for stylizing the image (eg: `mosaic.pth`)
 - `--output-image`: path for saving the output image.
 - `--content-scale`: factor for scaling down the content image if memory is an issue (eg: value of 2 will halve the height and width of content-image)
-- `--cuda`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: set it to 1 for running on macOS GPU
+- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
+- `--mps`: use MPS device backend.
+- `--xpu`: use XPU device backend.
 
 Train model
 
@@ -40,8 +41,9 @@ There are several command line arguments, the important ones are listed below
 - `--dataset`: path to training dataset, the path should point to a folder containing another folder with all the training images. I used COCO 2014 Training images dataset [80K/13GB] [(download)](https://cocodataset.org/#download).
 - `--style-image`: path to style-image.
 - `--save-model-dir`: path to folder where trained model will be saved.
-- `--cuda`: set it to 1 for running on GPU, 0 for CPU.
-- `--mps`: set it to 1 for running on macOS GPU
+- `--cuda 0|1`: set it to 1 for running on GPU, 0 for CPU.
+- `--mps`: use MPS device backend.
+- `--xpu`: use XPU device backend.
 
 Refer to `neural_style/neural_style.py` for other command line arguments. For training new models you might have to tune the values of `--content-weight` and `--style-weight`. The mosaic style model shown above was trained with `--content-weight 1e5` and `--style-weight 1e10`. The remaining 3 models were also trained with similar order of weight parameters with slight variation in the `--style-weight` (`5e10` or `1e11`).
 

--- a/fast_neural_style/neural_style/neural_style.py
+++ b/fast_neural_style/neural_style/neural_style.py
@@ -33,8 +33,12 @@ def train(args):
         device = torch.device("cuda")
     elif args.mps:
         device = torch.device("mps")
+    elif args.xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
+
+    print("Device to use: ", device)
 
     np.random.seed(args.seed)
     torch.manual_seed(args.seed)
@@ -126,6 +130,9 @@ def train(args):
 
 def stylize(args):
     device = torch.device("cuda" if args.cuda else "cpu")
+    device = torch.device("xpu" if args.xpu else "cpu")
+    
+    print("Device to use: ", device)
 
     content_image = utils.load_image(args.content_image, scale=args.content_scale)
     content_transform = transforms.Compose([
@@ -219,6 +226,10 @@ def main():
                                   help="number of images after which the training loss is logged, default is 500")
     train_arg_parser.add_argument("--checkpoint-interval", type=int, default=2000,
                                   help="number of batches after which a checkpoint of the trained model will be created")
+    train_arg_parser.add_argument('--mps', action='store_true',
+                                  help='enable macOS GPU training')
+    train_arg_parser.add_argument('--xpu', action='store_true',
+                                  help='enable Intel XPU training')
 
     eval_arg_parser = subparsers.add_parser("eval", help="parser for evaluation/stylizing arguments")
     eval_arg_parser.add_argument("--content-image", type=str, required=True,
@@ -233,7 +244,11 @@ def main():
                                  help="set it to 1 for running on cuda, 0 for CPU")
     eval_arg_parser.add_argument("--export_onnx", type=str,
                                  help="export ONNX model to a given file")
-    eval_arg_parser.add_argument('--mps', action='store_true', default=False, help='enable macOS GPU training')
+    eval_arg_parser.add_argument('--mps', action='store_true',
+                                 help='enable macOS GPU evaluation')
+    eval_arg_parser.add_argument('--xpu', action='store_true',
+                                 help='enable Intel XPU evaluation')
+
 
     args = main_arg_parser.parse_args()
 
@@ -245,6 +260,8 @@ def main():
         sys.exit(1)
     if not args.mps and torch.backends.mps.is_available():
         print("WARNING: mps is available, run with --mps to enable macOS GPU")
+    if not args.xpu and torch.xpu.is_available():
+        print("WARNING: XPU is available, run with --xpu to enable Intel XPU")
 
     if args.subcommand == "train":
         check_paths(args)

--- a/mnist/main.py
+++ b/mnist/main.py
@@ -82,21 +82,24 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-cuda', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
+    parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--no-xpu', action='store_true',
+                        help='disables Intel GPU training')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='For Saving the current Model')
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
+    use_xpu = not args.no_mps and torch.xpu.is_available()
 
     torch.manual_seed(args.seed)
 
@@ -104,6 +107,8 @@ def main():
         device = torch.device("cuda")
     elif use_mps:
         device = torch.device("mps")
+    elif use_xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
 

--- a/mnist_forward_forward/README.md
+++ b/mnist_forward_forward/README.md
@@ -18,6 +18,7 @@ optional arguments:
   --lr LR               learning rate (default: 0.03)
   --no_cuda             disables CUDA training
   --no_mps              disables MPS training
+  --no_xpu              disables XPU training
   --seed SEED           random seed (default: 1)
   --save_model          For saving the current Model
   --train_size TRAIN_SIZE

--- a/mnist_forward_forward/main.py
+++ b/mnist_forward_forward/main.py
@@ -102,10 +102,13 @@ if __name__ == "__main__":
         help="learning rate (default: 0.03)",
     )
     parser.add_argument(
-        "--no_cuda", action="store_true", default=False, help="disables CUDA training"
+        "--no_cuda", action="store_true", help="disables CUDA training"
     )
     parser.add_argument(
-        "--no_mps", action="store_true", default=False, help="disables MPS training"
+        "--no_mps", action="store_true", help="disables MPS training"
+    )
+    parser.add_argument(
+        "--no_xpu", action="store_true", help="disables XPU training"
     )
     parser.add_argument(
         "--seed", type=int, default=1, metavar="S", help="random seed (default: 1)"
@@ -113,7 +116,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save_model",
         action="store_true",
-        default=False,
         help="For saving the current Model",
     )
     parser.add_argument(
@@ -126,7 +128,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--save-model",
         action="store_true",
-        default=False,
         help="For Saving the current Model",
     )
     parser.add_argument(
@@ -139,10 +140,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     use_cuda = not args.no_cuda and torch.cuda.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
+    use_xpu = not args.no_xpu and torch.xpu.is_available()
     if use_cuda:
         device = torch.device("cuda")
     elif use_mps:
         device = torch.device("mps")
+    elif use_xpu:
+        device = torch.device("xpu")
     else:
         device = torch.device("cpu")
 

--- a/mnist_rnn/README.md
+++ b/mnist_rnn/README.md
@@ -8,3 +8,20 @@ pip install -r requirements.txt
 python main.py
 # CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+```bash
+optional arguments:
+  -h, --help            show this help message and exit
+  --batch_size          input batch_size for training (default:64)
+  --testing_batch_size  input batch size for testing (default: 1000)
+  --epochs EPOCHS       number of epochs to train (default: 14)
+  --lr LR               learning rate (default: 0.1)
+  --gamma               learning rate step gamma (default: 0.7)
+  --cuda                enables CUDA training
+  --xpu                 enables XPU training
+  --mps                 enables macos GPU training
+  --seed SEED           random seed (default: 1)
+  --save_model          For saving the current Model
+  --log_interval        how many batches to wait before logging training status
+  --dry-run             quickly check a single pass
+```

--- a/mnist_rnn/main.py
+++ b/mnist_rnn/main.py
@@ -93,15 +93,17 @@ def main():
                         help='learning rate step gamma (default: 0.7)')
     parser.add_argument('--cuda', action='store_true', default=False,
                         help='enables CUDA training')
-    parser.add_argument('--mps', action="store_true", default=False,
+    parser.add_argument('--mps', action="store_true", 
                         help="enables MPS training")
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--xpu', action='store_true',
+                        help='enables XPU training')
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='for Saving the current Model')
     args = parser.parse_args()
 
@@ -109,6 +111,8 @@ def main():
         device = "cuda"
     elif args.mps and not args.cuda:
         device = "mps"
+    elif args.xpu:
+        device = "xpu"
     else:
         device = "cpu"
 

--- a/siamese_network/README.md
+++ b/siamese_network/README.md
@@ -1,7 +1,42 @@
 # Siamese Network Example
 
+Siamese network for image similarity estimation.
+The network is composed of two identical networks, one for each input.
+The output of each network is concatenated and passed to a linear layer.
+The output of the linear layer passed through a sigmoid function.
+[FaceNet](https://arxiv.org/pdf/1503.03832.pdf) is a variant of the Siamese network.
+This implementation varies from FaceNet as we use the `ResNet-18` model from
+[Deep Residual Learning for Image Recognition](https://arxiv.org/pdf/1512.03385.pdf) as our feature extractor.
+In addition, we aren't using `TripletLoss` as the MNIST dataset is simple, so `BCELoss` can do the trick.
+
 ```bash
 pip install -r requirements.txt
 python main.py
-# CUDA_VISIBLE_DEVICES=2 python main.py  # to specify GPU id to ex. 2
 ```
+
+Optionally, you can add the following arguments to customize your execution.
+
+```bash
+--batch-size            input batch size for training (default: 64)
+--test-batch-size       input batch size for testing (default: 1000)
+--epochs                number of epochs to train (default: 14)
+--lr                    learning rate (default: 1.0)
+--gamma                 learning rate step gamma (default: 0.7)
+--no-cuda               disables CUDA training
+--no-xpu                disables XPU training
+--no-mps                disables macOS GPU training
+--dry-run               quickly check a single pass
+--seed                  random seed (default: 1)
+--log-interval          how many batches to wait before logging training status
+--save-model            Saving the current Model
+```
+
+If a GPU device (CUDA, XPU, or MPS) is detected, the example will be executed on the GPU by default; otherwise, it will run on the CPU.
+
+To disable the GPU option, add the appropriate argument to the command. For example:
+
+```bash
+python main.py --no-xpu
+```
+
+This command will execute the example on the CPU even if your system successfully detects an XPU.

--- a/siamese_network/main.py
+++ b/siamese_network/main.py
@@ -247,31 +247,38 @@ def main():
                         help='learning rate (default: 1.0)')
     parser.add_argument('--gamma', type=float, default=0.7, metavar='M',
                         help='Learning rate step gamma (default: 0.7)')
-    parser.add_argument('--no-cuda', action='store_true', default=False,
+    parser.add_argument('--no-cuda', action='store_true',
                         help='disables CUDA training')
-    parser.add_argument('--no-mps', action='store_true', default=False,
+    parser.add_argument('--no-xpu', action='store_true',
+                        help='disables XPU training')
+    parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
-    parser.add_argument('--dry-run', action='store_true', default=False,
+    parser.add_argument('--dry-run', action='store_true',
                         help='quickly check a single pass')
     parser.add_argument('--seed', type=int, default=1, metavar='S',
                         help='random seed (default: 1)')
     parser.add_argument('--log-interval', type=int, default=10, metavar='N',
                         help='how many batches to wait before logging training status')
-    parser.add_argument('--save-model', action='store_true', default=False,
+    parser.add_argument('--save-model', action='store_true',
                         help='For Saving the current Model')
     args = parser.parse_args()
     
     use_cuda = not args.no_cuda and torch.cuda.is_available()
+    use_xpu = not args.no_xpu and torch.xpu.is_available()
     use_mps = not args.no_mps and torch.backends.mps.is_available()
 
     torch.manual_seed(args.seed)
 
     if use_cuda:
         device = torch.device("cuda")
+    elif use_xpu:
+        device = torch.device("xpu")
     elif use_mps:
         device = torch.device("mps")
     else:
         device = torch.device("cpu")
+
+    print('Device to use: ', device)
 
     train_kwargs = {'batch_size': args.batch_size}
     test_kwargs = {'batch_size': args.test_batch_size}

--- a/vae/README.md
+++ b/vae/README.md
@@ -14,8 +14,9 @@ The main.py script accepts the following arguments:
 optional arguments:
   --batch-size		input batch size for training (default: 128)
   --epochs		number of epochs to train (default: 10)
-  --no-cuda		enables CUDA training
-  --mps         enables GPU on macOS
+  --no-cuda		disables CUDA training
+  --no-mps	        disables GPU on macOS
+  --no-xpu		disables XPU training in Intel GPUs
   --seed		random seed (default: 1)
   --log-interval	how many batches to wait before logging training status
 ```

--- a/vae/main.py
+++ b/vae/main.py
@@ -13,10 +13,12 @@ parser.add_argument('--batch-size', type=int, default=128, metavar='N',
                     help='input batch size for training (default: 128)')
 parser.add_argument('--epochs', type=int, default=10, metavar='N',
                     help='number of epochs to train (default: 10)')
-parser.add_argument('--no-cuda', action='store_true', default=False,
+parser.add_argument('--no-cuda', action='store_true',
                     help='disables CUDA training')
-parser.add_argument('--no-mps', action='store_true', default=False,
+parser.add_argument('--no-mps', action='store_true',
                         help='disables macOS GPU training')
+parser.add_argument('--no-xpu', action='store_true',
+                        help='disables Intel XPU training')
 parser.add_argument('--seed', type=int, default=1, metavar='S',
                     help='random seed (default: 1)')
 parser.add_argument('--log-interval', type=int, default=10, metavar='N',
@@ -24,6 +26,7 @@ parser.add_argument('--log-interval', type=int, default=10, metavar='N',
 args = parser.parse_args()
 args.cuda = not args.no_cuda and torch.cuda.is_available()
 use_mps = not args.no_mps and torch.backends.mps.is_available()
+use_xpu = not args.no_xpu and torch.xpu.is_available()
 
 torch.manual_seed(args.seed)
 
@@ -31,8 +34,12 @@ if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
+
+print('Device to use: ', device)
 
 kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
 train_loader = torch.utils.data.DataLoader(

--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -5,10 +5,14 @@ The trained model can then be used by the generate script to generate new text.
 
 ```bash
 python main.py --cuda --epochs 6           # Train a LSTM on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6            # Train a LSTM on Wikitext-2 with Intel XPU.
 python main.py --cuda --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with intel XPU.
 python main.py --cuda --tied               # Train a tied LSTM on Wikitext-2 with CUDA for 40 epochs.
 python main.py --cuda --epochs 6 --model Transformer --lr 5
                                            # Train a Transformer model on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6 --model Transformer --lr 5
+                                           # Train a Transformer model on Wikitext-2 with XPU.
 
 python generate.py                         # Generate samples from the default model checkpoint.
 ```
@@ -36,6 +40,7 @@ optional arguments:
   --tied                tie the word embedding and softmax weights
   --seed SEED           random seed
   --cuda                use CUDA
+  --xpu                 use Intel XPU
   --mps                 enable GPU on macOS
   --log-interval N      report interval
   --save SAVE           path to save the final model
@@ -53,4 +58,5 @@ python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
 python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --tied
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
+python main.py --xpu --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
 ```

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -8,6 +8,7 @@ import argparse
 import torch
 
 import data
+import model
 
 parser = argparse.ArgumentParser(description='PyTorch Wikitext-2 Language Model')
 # Model parameters.
@@ -15,6 +16,8 @@ parser.add_argument('--data', type=str, default='./data/wikitext-2',
                     help='location of the data corpus')
 parser.add_argument('--checkpoint', type=str, default='./model.pt',
                     help='model checkpoint to use')
+parser.add_argument('--model', type=str, default='LSTM',
+                    help='type of network (RNN_TANH, RNN_RELU, LSTM, GRU, Transformer)')
 parser.add_argument('--outf', type=str, default='generated.txt',
                     help='output file for generated text')
 parser.add_argument('--words', type=int, default='1000',
@@ -23,6 +26,8 @@ parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
 parser.add_argument('--cuda', action='store_true',
                     help='use CUDA')
+parser.add_argument('--xpu', action='store_true',
+                    help='use XPU')
 parser.add_argument('--mps', action='store_true', default=False,
                         help='enables macOS GPU training')
 parser.add_argument('--temperature', type=float, default=1.0,
@@ -39,20 +44,33 @@ if torch.cuda.is_available():
 if torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
+if torch.xpu.is_available():
+    if not args.xpu:
+        print("WARNING: You have XPU device, to enable XPU run with --xpu.")
         
 use_mps = args.mps and torch.backends.mps.is_available()
+use_xpu = args.xpu and torch.xpu.is_available()
 if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
 
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
+if args.model == 'Transformer':
+    model = model.TransformerModel()
+else:
+    model = model.RNNModel()
+
+
 with open(args.checkpoint, 'rb') as f:
-    model = torch.load(f, map_location=device)
+    # model = torch.load(f, map_location=device)
+    model.load_state_dict(torch.load(f), map_location=device)
 model.eval()
 
 corpus = data.Corpus(args.data)

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -84,7 +84,6 @@ else:
 
 
 with open(args.checkpoint, 'rb') as f:
-    # model = torch.load(f, map_location=device)
     model.load_state_dict(torch.load(f, map_location=device))
 
 model.eval()

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -63,14 +63,15 @@ if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
 if args.model == 'Transformer':
-    model = model.TransformerModel()
+    model = model.TransformerModel
 else:
-    model = model.RNNModel()
+    model = model.RNNModel
 
 
 with open(args.checkpoint, 'rb') as f:
     # model = torch.load(f, map_location=device)
-    model.load_state_dict(torch.load(f), map_location=device)
+    model.load_state_dict(torch.load(f))
+
 model.eval()
 
 corpus = data.Corpus(args.data)

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -34,6 +34,18 @@ parser.add_argument('--temperature', type=float, default=1.0,
                     help='temperature - higher will increase diversity')
 parser.add_argument('--log-interval', type=int, default=100,
                     help='reporting interval')
+parser.add_argument('--emsize', type=int, default=200,
+                    help='size of word embeddings')
+parser.add_argument('--nhead', type=int, default=2,
+                    help='the number of heads in the encoder/decoder of the transformer model')
+parser.add_argument('--nhid', type=int, default=200,
+                    help='number of hidden units per layer')
+parser.add_argument('--nlayers', type=int, default=2,
+                    help='number of layers')
+parser.add_argument('--dropout', type=float, default=0.2,
+                    help='dropout applied to layers (0 = no dropout)')
+parser.add_argument('--tied', action='store_true',
+                    help='tie the word embedding and softmax weights')
 args = parser.parse_args()
 
 # Set the random seed manually for reproducibility.
@@ -62,20 +74,20 @@ else:
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
+corpus = data.Corpus(args.data)
+ntokens = len(corpus.dictionary)
+
 if args.model == 'Transformer':
-    model = model.TransformerModel
+    model = model.TransformerModel(ntokens, args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout).to(device)
 else:
-    model = model.RNNModel
+    model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid, args.nlayers, args.dropout, args.tied).to(device)
 
 
 with open(args.checkpoint, 'rb') as f:
     # model = torch.load(f, map_location=device)
-    model.load_state_dict(torch.load(f))
+    model.load_state_dict(torch.load(f, map_location=device))
 
 model.eval()
-
-corpus = data.Corpus(args.data)
-ntokens = len(corpus.dictionary)
 
 is_transformer_model = hasattr(model, 'model_type') and model.model_type == 'Transformer'
 if not is_transformer_model:

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -113,6 +113,7 @@ test_data = batchify(corpus.test, eval_batch_size)
 ###############################################################################
 # Build the model
 ###############################################################################
+# torch.serialization.add_safe_globals([model.RNNModel, model.TransformerModel])
 
 ntokens = len(corpus.dictionary)
 if args.model == 'Transformer':
@@ -241,6 +242,7 @@ try:
         if not best_val_loss or val_loss < best_val_loss:
             with open(args.save, 'wb') as f:
                 torch.save(model.state_dict(), f)
+                # torch.save(model, f)
             best_val_loss = val_loss
         else:
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
@@ -252,10 +254,12 @@ except KeyboardInterrupt:
 # Load the best saved model.
 with open(args.save, 'rb') as f:
     model.load_state_dict(torch.load(f))
+    # torch.serialization.add_safe_globals([model])
+    # model = torch.load(f)
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.
-    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU']:
+    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU'] and args.cuda:
         model.rnn.flatten_parameters()
 
 # Run on test data.

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -41,6 +41,8 @@ parser.add_argument('--cuda', action='store_true', default=False,
                     help='use CUDA')
 parser.add_argument('--mps', action='store_true', default=False,
                         help='enables macOS GPU training')
+parser.add_argument('--xpu', action='store_true', default=False,
+                    help='Enables XPU usage')
 parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')
 parser.add_argument('--save', type=str, default='model.pt',
@@ -61,12 +63,18 @@ if torch.cuda.is_available():
 if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
+if torch.xpu.is_available():
+    if not args.xpu:
+        print("WARNING: You have XPU device, to enable XPU run with --xpu.")
 
 use_mps = args.mps and torch.backends.mps.is_available()
+use_xpu = args.xpu and torch.xpu.is_available()
 if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
 
@@ -232,7 +240,7 @@ try:
         # Save the model if the validation loss is the best we've seen so far.
         if not best_val_loss or val_loss < best_val_loss:
             with open(args.save, 'wb') as f:
-                torch.save(model, f)
+                torch.save(model.state_dict(), f)
             best_val_loss = val_loss
         else:
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
@@ -243,7 +251,7 @@ except KeyboardInterrupt:
 
 # Load the best saved model.
 with open(args.save, 'rb') as f:
-    model = torch.load(f)
+    model.load_state_dict(torch.load(f))
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -113,8 +113,6 @@ test_data = batchify(corpus.test, eval_batch_size)
 ###############################################################################
 # Build the model
 ###############################################################################
-# torch.serialization.add_safe_globals([model.RNNModel, model.TransformerModel])
-
 ntokens = len(corpus.dictionary)
 if args.model == 'Transformer':
     model = model.TransformerModel(ntokens, args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout).to(device)
@@ -254,8 +252,6 @@ except KeyboardInterrupt:
 # Load the best saved model.
 with open(args.save, 'rb') as f:
     model.load_state_dict(torch.load(f))
-    # torch.serialization.add_safe_globals([model])
-    # model = torch.load(f)
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.


### PR DESCRIPTION
- Add venv to .gitignore to allow clean environments
- Add arguments to generate.py to allow for state_dict loading instead of full model
- Update README to account for XPU new argument