### PR TITLE
Add support for Intel GPU to Word Language Model Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ docs/venv
 
 # development
 .vscode
+.venv
 **/.DS_Store

--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -5,10 +5,14 @@ The trained model can then be used by the generate script to generate new text.
 
 ```bash
 python main.py --cuda --epochs 6           # Train a LSTM on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6            # Train a LSTM on Wikitext-2 with Intel XPU.
 python main.py --cuda --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with intel XPU.
 python main.py --cuda --tied               # Train a tied LSTM on Wikitext-2 with CUDA for 40 epochs.
 python main.py --cuda --epochs 6 --model Transformer --lr 5
                                            # Train a Transformer model on Wikitext-2 with CUDA.
+python main.py --xpu --epochs 6 --model Transformer --lr 5
+                                           # Train a Transformer model on Wikitext-2 with XPU.
 
 python generate.py                         # Generate samples from the default model checkpoint.
 ```
@@ -36,6 +40,7 @@ optional arguments:
   --tied                tie the word embedding and softmax weights
   --seed SEED           random seed
   --cuda                use CUDA
+  --xpu                 use Intel XPU
   --mps                 enable GPU on macOS
   --log-interval N      report interval
   --save SAVE           path to save the final model
@@ -53,4 +58,5 @@ python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
 python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --tied
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40
 python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
+python main.py --xpu --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
 ```

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -8,6 +8,7 @@ import argparse
 import torch
 
 import data
+import model
 
 parser = argparse.ArgumentParser(description='PyTorch Wikitext-2 Language Model')
 # Model parameters.
@@ -15,6 +16,8 @@ parser.add_argument('--data', type=str, default='./data/wikitext-2',
                     help='location of the data corpus')
 parser.add_argument('--checkpoint', type=str, default='./model.pt',
                     help='model checkpoint to use')
+parser.add_argument('--model', type=str, default='LSTM',
+                    help='type of network (RNN_TANH, RNN_RELU, LSTM, GRU, Transformer)')
 parser.add_argument('--outf', type=str, default='generated.txt',
                     help='output file for generated text')
 parser.add_argument('--words', type=int, default='1000',
@@ -23,6 +26,8 @@ parser.add_argument('--seed', type=int, default=1111,
                     help='random seed')
 parser.add_argument('--cuda', action='store_true',
                     help='use CUDA')
+parser.add_argument('--xpu', action='store_true',
+                    help='use XPU')
 parser.add_argument('--mps', action='store_true', default=False,
                         help='enables macOS GPU training')
 parser.add_argument('--temperature', type=float, default=1.0,
@@ -39,20 +44,33 @@ if torch.cuda.is_available():
 if torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
+if torch.xpu.is_available():
+    if not args.xpu:
+        print("WARNING: You have XPU device, to enable XPU run with --xpu.")
         
 use_mps = args.mps and torch.backends.mps.is_available()
+use_xpu = args.xpu and torch.xpu.is_available()
 if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
 
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
+if args.model == 'Transformer':
+    model = model.TransformerModel()
+else:
+    model = model.RNNModel()
+
+
 with open(args.checkpoint, 'rb') as f:
-    model = torch.load(f, map_location=device)
+    # model = torch.load(f, map_location=device)
+    model.load_state_dict(torch.load(f), map_location=device)
 model.eval()
 
 corpus = data.Corpus(args.data)

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -84,7 +84,6 @@ else:
 
 
 with open(args.checkpoint, 'rb') as f:
-    # model = torch.load(f, map_location=device)
     model.load_state_dict(torch.load(f, map_location=device))
 
 model.eval()

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -63,14 +63,15 @@ if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
 if args.model == 'Transformer':
-    model = model.TransformerModel()
+    model = model.TransformerModel
 else:
-    model = model.RNNModel()
+    model = model.RNNModel
 
 
 with open(args.checkpoint, 'rb') as f:
     # model = torch.load(f, map_location=device)
-    model.load_state_dict(torch.load(f), map_location=device)
+    model.load_state_dict(torch.load(f))
+
 model.eval()
 
 corpus = data.Corpus(args.data)

--- a/word_language_model/generate.py
+++ b/word_language_model/generate.py
@@ -34,6 +34,18 @@ parser.add_argument('--temperature', type=float, default=1.0,
                     help='temperature - higher will increase diversity')
 parser.add_argument('--log-interval', type=int, default=100,
                     help='reporting interval')
+parser.add_argument('--emsize', type=int, default=200,
+                    help='size of word embeddings')
+parser.add_argument('--nhead', type=int, default=2,
+                    help='the number of heads in the encoder/decoder of the transformer model')
+parser.add_argument('--nhid', type=int, default=200,
+                    help='number of hidden units per layer')
+parser.add_argument('--nlayers', type=int, default=2,
+                    help='number of layers')
+parser.add_argument('--dropout', type=float, default=0.2,
+                    help='dropout applied to layers (0 = no dropout)')
+parser.add_argument('--tied', action='store_true',
+                    help='tie the word embedding and softmax weights')
 args = parser.parse_args()
 
 # Set the random seed manually for reproducibility.
@@ -62,20 +74,20 @@ else:
 if args.temperature < 1e-3:
     parser.error("--temperature has to be greater or equal 1e-3.")
 
+corpus = data.Corpus(args.data)
+ntokens = len(corpus.dictionary)
+
 if args.model == 'Transformer':
-    model = model.TransformerModel
+    model = model.TransformerModel(ntokens, args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout).to(device)
 else:
-    model = model.RNNModel
+    model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid, args.nlayers, args.dropout, args.tied).to(device)
 
 
 with open(args.checkpoint, 'rb') as f:
     # model = torch.load(f, map_location=device)
-    model.load_state_dict(torch.load(f))
+    model.load_state_dict(torch.load(f, map_location=device))
 
 model.eval()
-
-corpus = data.Corpus(args.data)
-ntokens = len(corpus.dictionary)
 
 is_transformer_model = hasattr(model, 'model_type') and model.model_type == 'Transformer'
 if not is_transformer_model:

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -113,6 +113,7 @@ test_data = batchify(corpus.test, eval_batch_size)
 ###############################################################################
 # Build the model
 ###############################################################################
+# torch.serialization.add_safe_globals([model.RNNModel, model.TransformerModel])
 
 ntokens = len(corpus.dictionary)
 if args.model == 'Transformer':
@@ -241,6 +242,7 @@ try:
         if not best_val_loss or val_loss < best_val_loss:
             with open(args.save, 'wb') as f:
                 torch.save(model.state_dict(), f)
+                # torch.save(model, f)
             best_val_loss = val_loss
         else:
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
@@ -252,10 +254,12 @@ except KeyboardInterrupt:
 # Load the best saved model.
 with open(args.save, 'rb') as f:
     model.load_state_dict(torch.load(f))
+    # torch.serialization.add_safe_globals([model])
+    # model = torch.load(f)
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.
-    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU']:
+    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU'] and args.cuda:
         model.rnn.flatten_parameters()
 
 # Run on test data.

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -41,6 +41,8 @@ parser.add_argument('--cuda', action='store_true', default=False,
                     help='use CUDA')
 parser.add_argument('--mps', action='store_true', default=False,
                         help='enables macOS GPU training')
+parser.add_argument('--xpu', action='store_true', default=False,
+                    help='Enables XPU usage')
 parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')
 parser.add_argument('--save', type=str, default='model.pt',
@@ -61,12 +63,18 @@ if torch.cuda.is_available():
 if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
     if not args.mps:
         print("WARNING: You have mps device, to enable macOS GPU run with --mps.")
+if torch.xpu.is_available():
+    if not args.xpu:
+        print("WARNING: You have XPU device, to enable XPU run with --xpu.")
 
 use_mps = args.mps and torch.backends.mps.is_available()
+use_xpu = args.xpu and torch.xpu.is_available()
 if args.cuda:
     device = torch.device("cuda")
 elif use_mps:
     device = torch.device("mps")
+elif use_xpu:
+    device = torch.device("xpu")
 else:
     device = torch.device("cpu")
 
@@ -232,7 +240,7 @@ try:
         # Save the model if the validation loss is the best we've seen so far.
         if not best_val_loss or val_loss < best_val_loss:
             with open(args.save, 'wb') as f:
-                torch.save(model, f)
+                torch.save(model.state_dict(), f)
             best_val_loss = val_loss
         else:
             # Anneal the learning rate if no improvement has been seen in the validation dataset.
@@ -243,7 +251,7 @@ except KeyboardInterrupt:
 
 # Load the best saved model.
 with open(args.save, 'rb') as f:
-    model = torch.load(f)
+    model.load_state_dict(torch.load(f))
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.

--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -113,8 +113,6 @@ test_data = batchify(corpus.test, eval_batch_size)
 ###############################################################################
 # Build the model
 ###############################################################################
-# torch.serialization.add_safe_globals([model.RNNModel, model.TransformerModel])
-
 ntokens = len(corpus.dictionary)
 if args.model == 'Transformer':
     model = model.TransformerModel(ntokens, args.emsize, args.nhead, args.nhid, args.nlayers, args.dropout).to(device)
@@ -254,8 +252,6 @@ except KeyboardInterrupt:
 # Load the best saved model.
 with open(args.save, 'rb') as f:
     model.load_state_dict(torch.load(f))
-    # torch.serialization.add_safe_globals([model])
-    # model = torch.load(f)
     # after load the rnn params are not a continuous chunk of memory
     # this makes them a continuous chunk, and will speed up forward pass
     # Currently, only rnn model supports flatten_parameters function.


### PR DESCRIPTION
- Add venv to .gitignore to allow clean environments
- Add arguments to generate.py to allow for state_dict loading instead of full model
- Update README to account for XPU new argument